### PR TITLE
Wrong normalization coefficient shape

### DIFF
--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -10,7 +10,7 @@ def get_data_loader(args):
         trans = transforms.Compose([
             transforms.Scale(32),
             transforms.ToTensor(),
-            transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+            transforms.Normalize((0.5, ), (0.5, )),
         ])
         train_dataset = MNIST(root=args.dataroot, train=True, download=args.download, transform=trans)
         test_dataset = MNIST(root=args.dataroot, train=False, download=args.download, transform=trans)


### PR DESCRIPTION
MNIST is mono-channel so the normalization should be a single element tuple, not a three element tuple.