### PR TITLE
Fix gradient penalty to calculate norm batchwise

### DIFF
--- a/models/wgan_gradient_penalty.py
+++ b/models/wgan_gradient_penalty.py
@@ -321,6 +321,9 @@ class WGAN_GP(object):
                                    prob_interpolated.size()),
                                create_graph=True, retain_graph=True)[0]
 
+        # flatten the gradients to it calculates norm batchwise
+        gradients = gradients.view(gradients.size(0), -1)
+        
         grad_penalty = ((gradients.norm(2, dim=1) - 1) ** 2).mean() * self.lambda_term
         return grad_penalty
 


### PR DESCRIPTION
#40 Hello, it seems like the gradient penalty is calculated wrong, so I have fixed it.
The L2 Norm should be calculated on each samples (batches), then averaged through all the samples.
Thank you.