### PR TITLE
Fix generator loss backward direction in WGAN with clipping

### DIFF
--- a/models/wgan_clipping.py
+++ b/models/wgan_clipping.py
@@ -196,7 +196,7 @@ class WGAN_CP(object):
             fake_images = self.G(z)
             g_loss = self.D(fake_images)
             g_loss = g_loss.mean().mean(0).view(1)
-            g_loss.backward(one)
+            g_loss.backward(mone)
             g_cost = -g_loss
             self.g_optimizer.step()
             print(f'Generator iteration: {g_iter}/{self.generator_iters}, g_loss: {g_loss.data}')


### PR DESCRIPTION
Changed g_loss.backward(one) to g_loss.backward(mone) in the generator training step. The generator should maximize the critic's output on fake images, which means minimizing -E[D(G(z))]. Using backward(one) was training the generator in the wrong direction.

This fix makes the WGAN clipping implementation consistent with the WGAN gradient penalty implementation and aligns with the original WGAN paper.
